### PR TITLE
pyglet ColorBufferImage image_data member changed to get_image_data

### DIFF
--- a/endo.py
+++ b/endo.py
@@ -108,7 +108,7 @@ win.set_exclusive_mouse(True)
 win.set_mouse_cursor(cursor)
 
 win.dispatch_events() #always do a dispatch soon after creating a new window
-image.get_buffer_manager().get_color_buffer().image_data #necessary (for some reason) to ensure openGL drawing coordinates are in pixels with (0,0) in lower left corner
+image.get_buffer_manager().get_color_buffer().get_image_data #necessary (for some reason) to ensure openGL drawing coordinates are in pixels with (0,0) in lower left corner
 
 # Perform some calculations to convert stimulus measurements in degrees to pixels
 screen_width_in_degrees = math.degrees(math.atan((screen_width/2.0)/viewing_distance)*2)

--- a/exo.py
+++ b/exo.py
@@ -105,7 +105,7 @@ win.set_exclusive_mouse(True)
 win.set_mouse_cursor(cursor)
 
 win.dispatch_events() #always do a dispatch soon after creating a new window
-image.get_buffer_manager().get_color_buffer().image_data #necessary (for some reason) to ensure openGL drawing coordinates are in pixels with (0,0) in lower left corner
+image.get_buffer_manager().get_color_buffer().get_image_data #necessary (for some reason) to ensure openGL drawing coordinates are in pixels with (0,0) in lower left corner
 
 # Perform some calculations to convert stimulus measurements in degrees to pixels
 screen_width_in_degrees = math.degrees(math.atan((screen_width/2.0)/viewing_distance)*2)


### PR DESCRIPTION
I needed this change to get both endo.py and exo.py to run. Other than that well done!

macOS Mojave 10.14.5
Python 2.7.10
pyglet 1.4.1